### PR TITLE
Implemented Global

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ error \
 swap \
 regex \
 MandT \
+g \
 
 # leave above line blank
 

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ jaked.exe: $(SOURCES) license.cpp
 	cl /std:c++17 /EHa /O2 /Ob1 /Ox /Ot /MT $** /Fe:$@
 
 jaked_debug.exe: $(SOURCES)
-	cl /std:c++17 /EHa /Zi /DJAKED_DEBUG $** /Fe$@
+	cl /std:c++17 /EHa /Zi /GS /GR /RTCs /RTCu /Gz /DJAKED_DEBUG $** /Fe$@
 
 jaked_test.exe: jaked_test.cpp $(SOURCES) test\*.ixx 
-	cl /std:c++17 /EHa /Zi /DJAKED_TEST /DJAKED_TEST_SANITY_CHECK=$(JAKED_TEST_SANITY_CHECK) /bigobj jaked_test.cpp swapfile.cpp
+	cl /std:c++17 /EHa /Zi /GS /GR /RTCs /RTCu /Gz /DJAKED_TEST /DJAKED_TEST_SANITY_CHECK=$(JAKED_TEST_SANITY_CHECK) /bigobj jaked_test.cpp swapfile.cpp
 
 run_all_tests: jaked_test.exe jaked_debug.exe jaked.exe
 	jaked_test

--- a/doc/Global.md
+++ b/doc/Global.md
@@ -39,7 +39,7 @@ Behaviour
 
 Does a full sweep of the whole file and marks all matching lines.
 
-Then, iterates over each marked line that still exist, sets `.` to point to that line, and applies `command-list`.
+Then, iterates over each marked line that still exist, sets `.` to point to that line, and applies `command-list`. If any command fails, the `command-list` is interrupted, and `g` will continue with the next marked line.
 
 At the end, the current line is set by the last executed command.
 
@@ -55,12 +55,12 @@ Then, iterates over each marked line that still exists, echoes the current line,
 + a single `&`, which executes the previous `command-list`; or
 + a `command-list`.
 
-Errors are hidden. CTRL-C stops the command.
+Errors are hidden. If any command fails, the `command-list` is interrupted and `G` continues with the next marked line. CTRL-C stops the command.
 
 **v/re/command-list**
 
-Same as `g/re/`, but executed on lines that do not match `/re/`. Re**v**erse.
+Same as `g/re/`, but executed on lines that **do not** match `/re/`. Re**v**erse.
 
 **V/re/**
 
-Same as `G/re/`, but executed on lines that do not match `/re/`.
+Same as `G/re/`, but executed on lines that **do not** match `/re/`.

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -25,10 +25,10 @@ Regex
 + [x] //
 + [x] ??
 + [x] ranges based off of regexes
-+ [ ] g//
++ [x] g//
   * [x] mutiline "command-list"
   * [ ] a, i and c support
-+ [x] g/old/s//new/ applies s/old/new/ on all matching lines with no error reported
+  * [x] g/old/s//new/ applies s/old/new/ on all matching lines with no error reported
 + [ ] G//
 + [ ] v//
 + [ ] V//

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -26,8 +26,9 @@ Regex
 + [x] ??
 + [x] ranges based off of regexes
 + [ ] g//
-  * [ ] mutiline "command-list"
-+ [ ] g/old/s//new/ applies s/old/new/ on all matching lines with no error reported
+  * [x] mutiline "command-list"
+  * [ ] a, i and c support
++ [x] g/old/s//new/ applies s/old/new/ on all matching lines with no error reported
 + [ ] G//
 + [ ] v//
 + [ ] V//

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -158,7 +158,7 @@ Internals, Externals and Other Tasks
 ------------------------------------
 
 + [x] refactor string processing – done, implemented swapfile.
-  * [ ] refactor it again to use a byte array (required for multi-level undo support without reimagining the swapfile format)
+  * [x] refactor it again to use a byte array (required for multi-level undo support without reimagining the swapfile format) –we got pointers now, woot!
 + [x] scripting behaviour (cancel on error if !isatty)
 + [/] test that e&q cowardly refuse to exit
 + [x] utf8 with BOM

--- a/doc/UndoAndSwapFile.md
+++ b/doc/UndoAndSwapFile.md
@@ -51,7 +51,7 @@ In C++ land, the Swapfile can perform a very small number of operations:
 + read the `head`, `cut` and `undo` registers, which return the head of their respective lists (if any in the case of the latter two)
 + set the `cut` and `undo` list heads
 + add a new, unlinked `Line` to the text
-+ gc: this is called after the file is written. The goal is to reorder and compact the swap file. It effectively garbage collects disconnected lines via mark-and-sweep – so, obviously, try not to create loops.
++ ~~gc: this is called after the file is written. The goal is to reorder and compact the swap file. It effectively garbage collects disconnected lines via mark-and-sweep – so, obviously, try not to create loops.~~
 
 The Line object supports the following operations:
 
@@ -60,7 +60,7 @@ The Line object supports the following operations:
 + `text`: retrieves the associated `text` field
 + `length`: retrieves the associated `sz` field
 
-Lines are immutable because they are well packed in memory; memory management responsabilities are sort-of placed on the caller (even though you only have `new` and `gc`).
+Lines are immutable because they are well packed in memory; memory management responsabilities are sort-of placed on the caller (even though you only have `new` ~~and `gc`~~).
 
 All text manipulation commands use the Swapfile as storage, thus all manipulation commands use the above operations to achieve their goals.
 

--- a/doc/UndoAndSwapFile.md
+++ b/doc/UndoAndSwapFile.md
@@ -245,3 +245,17 @@ We will perform a 3,5s/re/fm/ which will affect all lines 3 and 4 and error out 
 240 if ex                                   ; if an exception was set,
         ! throw ex                          ; reraise
 ```
+
+g/// undo support
+-----------------
+
+This command has a more involved undo algorithm:
+
+1. it creates a disconnected phantom list; let's call it the GLOB list; its text is `1,$c`;
+2. it iterates over the whole current state of the TEXT list; for each line, it creates an indirect handle (`Swapfile::line(LinePtr->ref())`) in order to save the current line order
+3. it then goes through [its normal behaviour](Global.md).
+4. it sets the UNDO head to the GLOB head
+
+On undo, normal stuff happens. You would expect to end up with gibberish, and you would be right if the present never got to that point in the future where the author implemented indirect handles and undo support.
+
+Actually, let's clarify some more how undo will work in the multilevel undo case: The `c` command is bullshit. It actually goes through the GLOB list and relinks the pointed-to line to be the next pointed-to line. After undo completes, the UNDS (undo stack) list head is popped and UNDO set to the next element. That's going to be interesting to implement.

--- a/jaked.cpp
+++ b/jaked.cpp
@@ -561,7 +561,7 @@ namespace CommandsImpl {
             bool bomChecked = false;
             //g_state.nlines = 0;
             auto continueFrom = after->next();
-            cprintf<CPK::r>("will continue after %s with %s\n", (after) ? (after->text().c_str()) : "<EOF>", (continueFrom) ? continueFrom->text().c_str() : "<EOF>");
+            cprintf<CPK::r>("will continue after %s with %s\n", (after) ? (static_cast<std::string>(after->text()).c_str()) : "<EOF>", (continueFrom) ? static_cast<std::string>(continueFrom->text()).c_str() : "<EOF>");
             while(!feof(f) && (c = fgetc(f)) != EOF) {
                 if(CtrlC()) {
                     cprintf<CPK::CTRLC>("r: ctrlc invoked while reading\n");
@@ -580,7 +580,7 @@ namespace CommandsImpl {
                         bomChecked = true;
                     }
                     auto inserted = g_state.swapfile.line(s);
-                    cprintf<CPK::r>("linking %s -> %s\n", ((after) ? after->text().c_str() : "<EOF>"), (inserted->text().c_str()));
+                    cprintf<CPK::r>("linking %s -> %s\n", ((after) ? static_cast<std::string>(after->text()).c_str() : "<EOF>"), (static_cast<std::string>(inserted->text()).c_str()));
                     after->link(inserted);
                     after = inserted;
                     ++g_state.nlines;
@@ -594,11 +594,11 @@ namespace CommandsImpl {
                 auto inserted = g_state.swapfile.line(line.str());
                 after->link(inserted);
                 after = inserted;
-                cprintf<CPK::r>("linking %s -> %s\n", ((after) ? after->text().c_str() : "<EOF>"), (inserted->text().c_str()));
+                cprintf<CPK::r>("linking %s -> %s\n", ((after) ? static_cast<std::string>(after->text()).c_str() : "<EOF>"), (static_cast<std::string>(inserted->text()).c_str()));
                 ++g_state.nlines;
             }
             after->link(continueFrom);
-            cprintf<CPK::r>("linking %s -> %s\n", ((after) ? after->text().c_str() : "<EOF>"), (continueFrom) ? (continueFrom->text().c_str()) : "<EOF>");
+            cprintf<CPK::r>("linking %s -> %s\n", ((after) ? static_cast<std::string>(after->text()).c_str() : "<EOF>"), (continueFrom) ? (static_cast<std::string>(continueFrom->text()).c_str()) : "<EOF>");
             fclose(f);
             g_state.dirty = true;
             g_state.line = range.second + g_state.nlines - originalNlines;
@@ -695,7 +695,7 @@ namespace CommandsImpl {
             if(tail[0] == 'n') {
                 ss << first++ << '\t';
             }
-            for(auto c : i->text()) {
+            for(auto c : static_cast<std::string>(i->text())) {
                 if(isprint((unsigned char)c)) {
                     if(c == '\t') {
                         ss << "\\t";
@@ -734,7 +734,7 @@ namespace CommandsImpl {
                              }
                     } // switch(c)
                 } // else if non printable
-            } // for(c:i->text())
+            } // for(c:static_cast<std::string>(i->text()))
             ss << '$' << std::endl;
             i = i->next();
             g_state.writeStringFn(ss.str());
@@ -757,7 +757,7 @@ namespace CommandsImpl {
             if(tail[0] == 'n') {
                 ss << first++ << '\t';
             }
-            ss << i->text() << std::endl;
+            ss << static_cast<std::string>(i->text()) << std::endl;
             i = i->next();
             g_state.writeStringFn(ss.str());
             if(CtrlC()) return;
@@ -788,7 +788,7 @@ namespace CommandsImpl {
                 && it->next())
         {
             it = it->next();
-            //printf("Marking: %d %s\n", idx, it->text().c_str());
+            //printf("Marking: %d %s\n", idx, static_cast<std::string>(it->text()).c_str());
         }
         g_state.registers[tail[0]] = it;
     } // k
@@ -835,14 +835,14 @@ namespace CommandsImpl {
         auto i1 = g_state.swapfile.head();
         auto first = r.first, second = r.second;
         while(first-- > 0) {
-            cprintf<CPK::W>("skipping %s\n", (i1) ? i1->text().c_str() : "<EOF>");
+            cprintf<CPK::W>("skipping %s\n", (i1) ? static_cast<std::string>(i1->text()).c_str() : "<EOF>");
             i1 = i1->next();
         }
-        if(i1) cprintf<CPK::W>("Writing from %s\n", i1->text().c_str());
+        if(i1) cprintf<CPK::W>("Writing from %s\n", static_cast<std::string>(i1->text()).c_str());
         while(second-- > 0 && i1) {
-            if(i1) cprintf<CPK::W>("Writing %s\n", i1->text().c_str());
+            if(i1) cprintf<CPK::W>("Writing %s\n", static_cast<std::string>(i1->text()).c_str());
             nBytes += i1->length() + strlen("\n");
-            fprintf(f, "%s\n", i1->text().c_str());
+            fprintf(f, "%s\n", static_cast<std::string>(i1->text()).c_str());
             i1 = i1->next();
         }
         fclose(f);
@@ -1020,8 +1020,8 @@ namespace CommandsImpl {
         auto oldLinesDup = (oldLines) ? oldLines->Copy() : LinePtr();
         std::stringstream ss;
         while(oldLines) {
-            cprintf<CPK::j>("%s\n", oldLines->text().c_str());
-            ss << oldLines->text();
+            cprintf<CPK::j>("%s\n", static_cast<std::string>(oldLines->text()).c_str());
+            ss << static_cast<std::string>(oldLines->text());
             if(oldLines->next()) ss << tail;
             oldLines = oldLines->next();
         }
@@ -1123,7 +1123,7 @@ namespace CommandsImpl {
                 ex = std::make_exception_ptr(JakEDException("Internal error - EOF encountered"));
                 break;
             }
-            auto cx = ax->text(); // 90
+            auto cx = static_cast<std::string>(ax->text()); // 90
             if(!std::regex_search(cx, g_state.regexp)) { // 100
                 ex = std::make_exception_ptr(JakEDException("Line does not match")); // 110
             }
@@ -1248,7 +1248,7 @@ namespace CommandsImpl {
         int lines = 0;
         it->link(cutBuffer);
         while(cutBuffer) {
-            auto line = g_state.swapfile.line(cutBuffer->text());
+            auto line = g_state.swapfile.line(static_cast<std::string>(cutBuffer->text()));
             line->link(nextOne);
             it->link(line);
             it = line;
@@ -1289,7 +1289,7 @@ namespace CommandsImpl {
         it = it->next();
         idx = r.second - r.first + 1;
         while(idx-- > 0 && it) {
-            auto line = g_state.swapfile.line(it->text());
+            auto line = g_state.swapfile.line(static_cast<std::string>(it->text()));
             cutHead->link(line);
             cutHead = line;
             ++linesYanked;
@@ -1426,7 +1426,7 @@ namespace CommandsImpl {
         while(count--
                 && it)
         {
-            auto inserted = g_state.swapfile.line(it->text());
+            auto inserted = g_state.swapfile.line(static_cast<std::string>(it->text()));
             inserted->link(afterThis->next());
             afterThis->link(inserted);
 
@@ -1651,8 +1651,8 @@ std::tuple<Range, int> ParseRegister(std::string const& s, int i)
     auto it = g_state.swapfile.head();
     size_t index = 0;
     while(it != found->second && it) {
-        cprintf<CPK::regs>("%zd [%s]\n", index+1,it->text().c_str());
-        cprintf<CPK::parser>("%zd [%s]\n", index+1,it->text().c_str());
+        cprintf<CPK::regs>("%zd [%s]\n", index+1,static_cast<std::string>(it->text()).c_str());
+        cprintf<CPK::parser>("%zd [%s]\n", index+1,static_cast<std::string>(it->text()).c_str());
         it = it->next();
         ++index;
     }
@@ -1835,7 +1835,7 @@ std::tuple<int, int> ParseRegex(std::string s, int i)
     auto fromLine = g_state.line;
     int line = 0;
     cprintf<CPK::regex>("Finding line %d\n", fromLine);
-    while(ref && fromLine--) {
+    while(ref && (fromLine--)) {
         ++line;
         ref = ref->next();
         if(!ref) ref = g_state.swapfile.head()->next();
@@ -1843,7 +1843,7 @@ std::tuple<int, int> ParseRegex(std::string s, int i)
             throw JakEDException("Interrupted");
         }
     }
-    cprintf<CPK::regex>("line %d == fromLine %d, text == %s\n", line, g_state.line, ref->text().c_str());
+    cprintf<CPK::regex>("line %d == fromLine %d, text == %s\n", line, g_state.line, static_cast<std::string>(ref->text()).c_str());
     auto it = ref->Copy();
     if(s[0] == '/') {
         cprintf<CPK::regex>("Searching forward\n");
@@ -1855,8 +1855,8 @@ std::tuple<int, int> ParseRegex(std::string s, int i)
                 it = g_state.swapfile.head()->next();
                 line = 1;
             }
-            cprintf<CPK::regex>("Checking %s\n", it->text().c_str());
-            if(std::regex_search(it->text(), g_state.regexp)) {
+            cprintf<CPK::regex>("Checking %s\n", static_cast<std::string>(it->text()).c_str());
+            if(std::regex_search(static_cast<std::string>(it->text()), g_state.regexp)) {
                 cprintf<CPK::regex>("Found at %d\n", line);
                 return std::make_tuple(line, i + 1);
             }
@@ -1878,8 +1878,8 @@ std::tuple<int, int> ParseRegex(std::string s, int i)
                 cprintf<CPK::regex>("Vising self once\n");
                 flag = true;
             }
-            cprintf<CPK::regex>("Checking %s\n", it->text().c_str());
-            if(std::regex_search(it->text(), g_state.regexp)) {
+            cprintf<CPK::regex>("Checking %s\n", static_cast<std::string>(it->text()).c_str());
+            if(std::regex_search(static_cast<std::string>(it->text()), g_state.regexp)) {
                 cprintf<CPK::regex>("Found a match on line %d\n", line);
                 lastFound = line;
             }

--- a/jaked_test.cpp
+++ b/jaked_test.cpp
@@ -292,10 +292,15 @@ void DEFINE_SUITES() {
     DEF_SUITE(90_System) {
 #       include "test/90_System.ixx"
     } END_SUITE();
+
+    DEF_SUITE(95_Global) {
+#       include "test/95_Global.ixx"
+    } END_SUITE();
 }
 
 VOID CALLBACK killSelf(PVOID lpParam, BOOLEAN TimerOrWaitFired)
 {
+    if(IsDebuggerPresent()) return;
     if(TimerOrWaitFired) {
         fprintf(stderr, "Test suite max time hit\n");
         fflush(stderr);

--- a/swapfile.cpp
+++ b/swapfile.cpp
@@ -300,6 +300,7 @@ public:
         return p;
     }
 
+#if 0
     void gc() override
     {
         cprintf<CPK::swap>("[%p] gcing swap file\n", m_file);
@@ -347,6 +348,7 @@ public:
         std::swap(m_file, temp->m_file);
         std::swap(m_name, temp->m_name);
     }
+#endif
 };
 
 class MappedLine : public ILine
@@ -706,6 +708,7 @@ public:
         return p;
     }
 
+#if 0
     void gc() override
     {
         cprintf<CPK::swap>("[%p] gcing swap file\n", m_file);
@@ -758,6 +761,7 @@ public:
         std::swap(m_size, temp->m_size);
         std::swap(m_name, temp->m_name);
     }
+#endif
 };
 
 inline size_t MappedLine::length()
@@ -844,5 +848,5 @@ LinePtr Swapfile::undo() { return m_pImpl->undo(); }
 LinePtr Swapfile::line(std::string const& s) { return m_pImpl->line(s); }
 LinePtr Swapfile::undo(LinePtr const& l) { return m_pImpl->undo(l); }
 LinePtr Swapfile::cut(LinePtr const& l) { return m_pImpl->cut(l); }
-void Swapfile::gc() { return m_pImpl->gc(); }
+//void Swapfile::gc() { return m_pImpl->gc(); }
 

--- a/swapfile.h
+++ b/swapfile.h
@@ -104,12 +104,14 @@ struct ISwapImpl
     virtual LinePtr line(std::string const&) = 0;
     virtual LinePtr cut(LinePtr const&) = 0;
     virtual LinePtr undo(LinePtr const&) = 0;
+#if 0
     /**
       * gc the swap file. All LinePtr's will become invalid.
       * 
       * This compacts the swap file. Should be invoked after every write.
       */
     virtual void gc() = 0;
+#endif
 };
 
 inline ISwapImpl::~ISwapImpl() = default;

--- a/test/81_Substitute.ixx
+++ b/test/81_Substitute.ixx
@@ -36,7 +36,7 @@
                 ASSERT(!!g_state.swapfile.head());
                 ASSERT(!!g_state.swapfile.head()->next());
                 ASSERT(!!g_state.swapfile.head()->next()->next());
-                ASSERT(g_state.swapfile.head()->next()->next()->text() == "Line 2 ccb");
+                ASSERT(static_cast<std::string>(g_state.swapfile.head()->next()->next()->text()) == "Line 2 ccb");
             } TEST_RUN_END();
         } END_TEST();
 
@@ -52,7 +52,7 @@
                 ASSERT(!!g_state.swapfile.head());
                 ASSERT(!!g_state.swapfile.head()->next());
                 ASSERT(!!g_state.swapfile.head()->next()->next());
-                ASSERT(g_state.swapfile.head()->next()->next()->text() == "Line 2 ccb");
+                ASSERT(static_cast<std::string>(g_state.swapfile.head()->next()->next()->text()) == "Line 2 ccb");
             } TEST_RUN_END();
         } END_TEST();
 
@@ -67,7 +67,7 @@
                 ASSERT(g_state.line == 1);
                 ASSERT(!!g_state.swapfile.head());
                 ASSERT(!!g_state.swapfile.head()->next());
-                ASSERT(g_state.swapfile.head()->next()->text() == "Line 1 cca");
+                ASSERT(static_cast<std::string>(g_state.swapfile.head()->next()->text()) == "Line 1 cca");
             } TEST_RUN_END();
         } END_TEST();
 
@@ -82,7 +82,7 @@
                 ASSERT(g_state.line == 1);
                 ASSERT(!!g_state.swapfile.head());
                 ASSERT(!!g_state.swapfile.head()->next());
-                ASSERT(g_state.swapfile.head()->next()->text() == "Line 1 ccc");
+                ASSERT(static_cast<std::string>(g_state.swapfile.head()->next()->text()) == "Line 1 ccc");
             } TEST_RUN_END();
         } END_TEST();
 

--- a/test/85_MoveAndTransfer.ixx
+++ b/test/85_MoveAndTransfer.ixx
@@ -2,14 +2,14 @@
             // registers are preserved
             ASSERT(g_state.registers.find('q') != g_state.registers.end());
             ASSERT(!!g_state.registers.at('q'));
-            ASSERT(g_state.registers.at('q')->text() == "Line 3");
+            ASSERT(static_cast<std::string>(g_state.registers.at('q')->text()) == "Line 3");
             ASSERT(g_state.registers.find('w') != g_state.registers.end());
             ASSERT(!!g_state.registers.at('w'));
-            ASSERT(g_state.registers.at('w')->text() == "Line 4");
+            ASSERT(static_cast<std::string>(g_state.registers.at('w')->text()) == "Line 4");
             ASSERT(g_state.registers.at('q')->next() == g_state.registers.at('w'));
             ASSERT(g_state.registers.find('e') != g_state.registers.end());
             ASSERT(!!g_state.registers.at('e'));
-            ASSERT(g_state.registers.at('e')->text() == "Line 5");
+            ASSERT(static_cast<std::string>(g_state.registers.at('e')->text()) == "Line 5");
             ASSERT(g_state.registers.at('w')->next() == g_state.registers.at('e'));
         };
 

--- a/test/95_Global.ixx
+++ b/test/95_Global.ixx
@@ -26,6 +26,7 @@
 
         DEF_TEST(SuccessfulGSall) {
             auto fn = WriteFn({
+                "10",
                 "eniL 1 aaa",
                 "eniL 2 aab",
                 "eniL 3 aba",
@@ -41,6 +42,85 @@
                 auto state = std::make_shared<int>(0);
                 g_state.readCharFn = [state]() -> int {
                     auto s = R"(g/Line/s/\(L\)\(i\)\(n\)\(e\)/\4\3\2\1/
+.=
+,p
+)";
+                    if(*state >= strlen(s)) return EOF;
+                    return s[(*state)++];
+                };
+                g_state.writeStringFn = fn;
+            } TEST_SETUP_END();
+            TEST_TEARDOWN() {
+                setup();
+            } TEST_TEARDOWN_END();
+            TEST_RUN() {
+                g_state.line = 5;
+                Loop();
+                fn.Assert();
+            } TEST_RUN_END();
+        } END_TEST();
+
+        DEF_TEST(GSallIsSuccessfulHalfOfTheTime) {
+            auto fn = WriteFn({
+                "9",
+                "eniL 1 aaa",
+                "Line 2 aab",
+                "eniL 3 aba",
+                "Line 4 a a",
+                "eniL 5 ab a",
+                "Line 6 a ba",
+                "eniL 7 a b a",
+                "Line 8 b aa",
+                "eniL 9 aa b",
+                "Line 10 b a a",
+            });
+            TEST_SETUP() {
+                auto state = std::make_shared<int>(0);
+                g_state.readCharFn = [state]() -> int {
+                    auto s = R"(g/Line/s/\(L\)\(i\)\(n\)\(e\)\( [13579] \)/\4\3\2\1\5/
+.=
+,p
+)";
+                    if(*state >= strlen(s)) return EOF;
+                    return s[(*state)++];
+                };
+                g_state.writeStringFn = fn;
+            } TEST_SETUP_END();
+            TEST_TEARDOWN() {
+                setup();
+            } TEST_TEARDOWN_END();
+            TEST_RUN() {
+                g_state.line = 5;
+                Loop();
+                fn.Assert();
+            } TEST_RUN_END();
+        } END_TEST();
+
+        DEF_TEST(GSallIsSuccessfulHalfOfTheTimeWithExtraPrint) {
+            auto fn = WriteFn({
+                "eniL 1 aaa",
+                "eniL 3 aba",
+                "eniL 5 ab a",
+                "eniL 7 a b a",
+                "eniL 9 aa b",
+                "9",
+                "eniL 1 aaa",
+                "Line 2 aab",
+                "eniL 3 aba",
+                "Line 4 a a",
+                "eniL 5 ab a",
+                "Line 6 a ba",
+                "eniL 7 a b a",
+                "Line 8 b aa",
+                "eniL 9 aa b",
+                "Line 10 b a a",
+            });
+            TEST_SETUP() {
+                auto state = std::make_shared<int>(0);
+                g_state.readCharFn = [state]() -> int {
+                    auto s = R"(g/Line/s/\(L\)\(i\)\(n\)\(e\)\( [13579] \)/\4\3\2\1\5/\
+.p
+.=
 ,p
 )";
                     if(*state >= strlen(s)) return EOF;

--- a/test/95_Global.ixx
+++ b/test/95_Global.ixx
@@ -1,0 +1,59 @@
+        SUITE_SETUP() {
+            g_state();
+            auto after = g_state.swapfile.head();
+            std::string strs[] = {
+                "Line 1 aaa",
+                "Line 2 aab",
+                "Line 3 aba",
+                "Line 4 a a",
+                "Line 5 ab a",
+                "Line 6 a ba",
+                "Line 7 a b a",
+                "Line 8 b aa",
+                "Line 9 aa b",
+                "Line 10 b a a",
+            };
+            for(size_t i = 0; i < 10; ++i) {
+                auto line = g_state.swapfile.line(strs[i]);
+                after->link(line);
+                after = line;
+            }
+            g_state.nlines = 10;
+            g_state.line = 1;
+            g_state.readCharFn = FAIL_readCharFn;
+            g_state.writeStringFn = NULL_writeStringFn;
+        } SUITE_SETUP_END();
+
+        DEF_TEST(SuccessfulGSall) {
+            auto fn = WriteFn({
+                "eniL 1 aaa",
+                "eniL 2 aab",
+                "eniL 3 aba",
+                "eniL 4 a a",
+                "eniL 5 ab a",
+                "eniL 6 a ba",
+                "eniL 7 a b a",
+                "eniL 8 b aa",
+                "eniL 9 aa b",
+                "eniL 10 b a a",
+            });
+            TEST_SETUP() {
+                auto state = std::make_shared<int>(0);
+                g_state.readCharFn = [state]() -> int {
+                    auto s = R"(g/Line/s/\(L\)\(i\)\(n\)\(e\)/\4\3\2\1/
+,p
+)";
+                    if(*state >= strlen(s)) return EOF;
+                    return s[(*state)++];
+                };
+                g_state.writeStringFn = fn;
+            } TEST_SETUP_END();
+            TEST_TEARDOWN() {
+                setup();
+            } TEST_TEARDOWN_END();
+            TEST_RUN() {
+                g_state.line = 5;
+                Loop();
+                fn.Assert();
+            } TEST_RUN_END();
+        } END_TEST();


### PR DESCRIPTION
Implemented initial support for `g//`.

- fixed [test bed](jaked_test.cpp) to detect if debugger is attached and to stop murdering my debugging session (probably the most important fix)
- implement `g`
- `g` can parse a multi-line command list
- documented `g`
- switched from using `std::string` to using `Text` (which is a PascalString that can hold other stuff)
- implemented indirect line handles to compress the undo list for `g//`
- added 3 basic `g//` tests
- removed the `gc` call on `Swapfile` because that won't make sense with multi-level undo, and it would have interacted with `g//` in a bad way (invalidating LinePtr's)